### PR TITLE
Required jQuery

### DIFF
--- a/leankit-servicenow.tamper.js
+++ b/leankit-servicenow.tamper.js
@@ -4,6 +4,7 @@
 // @version        0.0.8
 // @description    replace servicenow identifiers in LeanKit with a link
 // @include        https://ksu.leankit.com/*
+// @require        http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @run-at         document-end
 // ==/UserScript==
 


### PR DESCRIPTION
Hello! I'm the web architect at LeanKit and we noticed recently that we're seeing an unusual number of ReferenceErrors in the browser on your account due to jQuery not being defined. Two of our web developers (@digitalBush and @elijahmanor) happened upon this repo and realized that the issue was a TamperMonkey script that wasn't including jQuery. We've recently updated parts of our site using a bundling process that does not put jQuery on the window, causing your script to fail. Since the TamperMonkey script is running every second, your browsers are notifying our logging server of uncaught exceptions at an unusually high rate (i.e. - over 4.5 million requests in the last 30 days). We can imagine that it's helpful for your script to create the Service Now links, so we wanted to send a PR that not only helps your script continue to work, but it alleviates the concern we have with the error logging traffic coming from your account.